### PR TITLE
update deps and stuff

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,14 @@
 language: erlang
 otp_release:
-  - R16B03-1
+  - 17.3
   - 17.1
+  - 17.0
+  - R16B03-1
+  - R16B02
+  - R16B01
+  - R16B
+
+sudo: false
 
 before-install:
   - sudo apt-get install wget curl

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ instance using a variant of the ```craterl:new()``` function:
 
 ```erlang
 ClientSpec = {local, my_client}.
-Servers = [{<<"localhost">>, 4200}, {<<"localhost">>, 4201}].
+Servers = [{<<"localhost">>, 4200}, "localhost:4201"].
 Options = [{poolsize, 1000}, {timeout, 5000}].
 ClientRef = craterl:new(ClientSpec, Servers, Options).
 ```
@@ -45,6 +45,23 @@ It is possible to create many clients on one erlang node.
 ```craterl``` client instances are created using a client spec which is
 a tuple you would use when registering a process, like ```{local, your_name}```.
 The process name, ```your_name``` in this example, must be unique on a node.
+
+### Options ###
+
+The following options can be used to change the behaviour of a newly created craterl client:
+
+    * poolname - ```string()``` or ```binary()```, the name of the connection pool, handled by hackney (erlang http client)
+    * poolsize - ```integer()```, the size of the connection pool, also handled by hackney
+    * timeout - ```integer()```, the receive and connect timeout for connections to crate servers, in milliseconds
+    * ssl_options - ```term()```, the same options the erlang ssl module accepts as ```ssloptions()```
+    * ssl_insecure - ```boolean()```, whether ssl certificates should be validated or not
+
+Example:
+
+```erlang
+Options = [{poolname, "my_pool"}, {poolsize, 200}, {timeout, 6000}, {ssl_insecure, false}, {ssl_options, [{cipers, [{rsa, aes_256_cbc, sha}]}, {cacerts, MyDerEncodedCaCerts}]}].
+ClientRef = craterl:new(craterl, [{<<"localhost", 4200}], Options).
+```
 
 See the documentation of the ```craterl``` module for more detailed api documentation.
 

--- a/include/craterl.hrl
+++ b/include/craterl.hrl
@@ -52,7 +52,7 @@
 
 -type craterl_client_spec() :: {local, atom()} | {global, atom()} | {via, atom(), atom()}.
 
--type craterl_server_spec() :: {binary(), non_neg_integer()}.
+-type craterl_server_spec() :: {binary(), non_neg_integer()} | string() | binary().
 
 -record(craterl_server_conf, {
   address :: craterl_server_spec(),

--- a/priv/ci/run_tests.sh
+++ b/priv/ci/run_tests.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-CRATE_DEFAULT_VERSION="0.45.5"
+CRATE_DEFAULT_VERSION="0.45.6"
 
 if [ "${CRATE_VERSION}x" = "x" ]
 then

--- a/rebar.config
+++ b/rebar.config
@@ -10,9 +10,9 @@
     debug_info]}.
 {deps,
   [
-    {lager, "2.0.3", {git, "https://github.com/basho/lager.git", {tag, "2.0.3"}}},
-    {jsx, "2.1.1", {git, "https://github.com/talentdeficit/jsx.git", {tag, "v2.1.1"}}},
-    {hackney,"1.0.0",{git,"https://github.com/benoitc/hackney",{tag,"1.0.0"}}}
+    {lager, "2.1.0", {git, "https://github.com/basho/lager.git", {tag, "2.1.0"}}},
+    {jsx, "2.4.0", {git, "https://github.com/talentdeficit/jsx.git", {tag, "v2.4.0"}}},
+    {hackney,"1.0.5",{git,"https://github.com/benoitc/hackney",{tag,"1.0.5"}}}
   ]
 }.
 {dev_only_deps,
@@ -26,3 +26,4 @@
 {ct_dir, "ct"}.
 {ct_log_dir, "ct/logs"}.
 {clean_files, [".eunit", "ebin/*.beam", "test/*.beam"]}.
+{require_otp_vsn, "R16|17"}.

--- a/rebar.config.lock
+++ b/rebar.config.lock
@@ -1,0 +1,42 @@
+%% THIS FILE IS GENERATED. DO NOT EDIT IT MANUALLY %%
+
+{erl_opts,[{platform_define,"^[0-9]+",namespaced_dicts},
+           warn_export_vars,warn_shadow_vars,warn_obsolete_guard,
+           warn_unused_import,warnings_as_errors,fail_on_warning,debug_info]}.
+{deps,[{edown,".*",
+              {git,"git://github.com/seth/edown.git",
+                   "30a9f7867d615af45783235faa52742d11a9348e"}},
+       {rebar_lock_deps_plugin,".*",
+                               {git,"git://github.com/seth/rebar_lock_deps_plugin.git",
+                                    "9711549b8a84b065eb2edc22f8eb6ff85e3c94e8"}},
+       {meck,".*",
+             {git,"https://github.com/eproxus/meck.git",
+                  "fd1c79361d4a5fa16774c8b378dd89104d3dfaa5"}},
+       {goldrush,".*",
+                 {git,"git://github.com/DeadZen/goldrush.git",
+                      "71e63212f12c25827e0c1b4198d37d5d018a7fec"}},
+       {lager,".*",
+              {git,"https://github.com/basho/lager.git",
+                   "b6b6cebcb27ccff8acc59ae775acebc2f52e4926"}},
+       {jsx,".*",
+            {git,"https://github.com/talentdeficit/jsx.git",
+                 "4d549dd8a990e282c3d57c5f73213674c05ebf07"}},
+       {idna,".*",
+             {git,"https://github.com/benoitc/erlang-idna",
+                  "5089240e653ce254273da9cff57952a60b1d2c51"}},
+       {ssl_verify_hostname,".*",
+                            {git,"https://github.com/benoitc/ssl_verify_hostname",
+                                 "3e7179789603057e3ec1867802c74c7bf6f8528a"}},
+       {hackney,".*",
+                {git,"https://github.com/benoitc/hackney",
+                     "384a30b28a2db6ae645d9eba09e2884830044e53"}}]}.
+{dev_only_deps,[{meck,"0.8.2",
+                      {git,"https://github.com/eproxus/meck.git",
+                           {branch,"master"}}}]}.
+{eunit_opts,[verbose,{report,{eunit_surefire,[{dir,"."}]}}]}.
+{cover_enabled,true}.
+{cover_export_enabled,true}.
+{ct_dir,"ct"}.
+{ct_log_dir,"ct/logs"}.
+{clean_files,[".eunit","ebin/*.beam","test/*.beam"]}.
+

--- a/src/craterl.erl
+++ b/src/craterl.erl
@@ -124,7 +124,8 @@ new(Servers, Options) when is_list(Options) ->
 %%--------------------------------------------------------------------
 -spec new(ClientSpec:: craterl_client_spec(), Servers::[craterl_server_spec()], Options::[term()]) -> atom().
 new(ClientSpec, Servers, Options) ->
-  craterl_sup:start_client(ClientSpec, Servers, Options).
+  NormalizedServers = lists:map(fun(Spec) -> craterl_url:server_spec(Spec) end, Servers),
+  craterl_sup:start_client(ClientSpec, NormalizedServers, Options).
 
 %%--------------------------------------------------------------------
 %% @doc

--- a/src/craterl_url.erl
+++ b/src/craterl_url.erl
@@ -31,7 +31,8 @@
 
 %% API
 -export([
-  create_server_url/2
+  create_server_url/2,
+  server_spec/1
 ]).
 
 -ifdef(TEST).
@@ -59,3 +60,13 @@ create_server_url({Host, Port}, Path) when is_binary(Path) ->
     <<"https://", _/binary>> -> Url;
     <<_/binary>> -> <<"http://", Url/binary>>
   end.
+
+
+-spec server_spec({binary(), integer()}|string()|binary()) -> {binary(), integer()}.
+server_spec({Host, Port}=HostPort) when is_binary(Host), is_integer(Port) ->
+  HostPort;
+server_spec(HostPort) when is_list(HostPort) ->
+  server_spec(list_to_binary(HostPort));
+server_spec(HostPort) when is_binary(HostPort) ->
+  [Host, Port] = binary:split(HostPort, <<":">>),
+  {Host, binary_to_integer(Port)}.

--- a/test/craterl_api_tests.erl
+++ b/test/craterl_api_tests.erl
@@ -193,6 +193,8 @@ new_test_() -> {
         ?_assertEqual(ok, craterl:stop_client(craterl)),
         ?_assertEqual([], supervisor:which_children(craterl_sup)),
         ?_assertEqual(craterl, craterl:new([?CRATERL_DEFAULT_SERVER])),
+        ?_assertEqual(string, craterl:new({local, string}, ["localhost:4200"], [])),
+        ?_assertEqual(binary, craterl:new({local, binary}, [<<"localhost:4200">>], [])),
         ?_assertEqual({error, {already_started, craterl}}, craterl:new([?CRATERL_DEFAULT_SERVER], [{poolsize, 100}])),
         ?_assertEqual(ok, craterl:stop_client(craterl)),
         ?_assertEqual(craty, craterl:new({local, craty}, [?CRATERL_DEFAULT_SERVER], [])),


### PR DESCRIPTION
* some docs about possible options
* more otp versions to test against on travis-ci
* allow strings and binaries as server specs
* integration tests against new stable release 0.45.6